### PR TITLE
Enable user specified block lists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules/
 *.tgz
 
 lib
+*.iml

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@prizemates/http-firewall",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "HTTP Firewall based on Spring Security HttpFirewall",
   "private": false,
   "main": "./lib/index.js",

--- a/src/__tests__/strict-http-firewall.tests.ts
+++ b/src/__tests__/strict-http-firewall.tests.ts
@@ -147,6 +147,24 @@ describe('HttpStrictFirewall test suite', () => {
       expect(res.statusCode).toBe(403);
     });
 
+    it('Should reject request when user provided decoded url block list is provided', async () => {
+      const app = express();
+
+      const options: HttpFirewallOptions = {decodedUrlBlockList : ['.exe', '.pl']};
+      app.use(httpFirewall(options));
+      const res = await request(app).get('/test/some-file.exe').set('Content-Type', 'application/json');
+      expect(res.statusCode).toBe(403);
+    });
+
+    it('Should reject request when user provided encoded url block list is provided', async () => {
+      const app = express();
+
+      const options: HttpFirewallOptions = {encodedUrlBlockList : ['.exe', '.pl']};
+      app.use(httpFirewall(options));
+      const res = await request(app).get('/test/some-file.exe').set('Content-Type', 'application/json');
+      expect(res.statusCode).toBe(403);
+    });
+
     it('Should allow encoded period when permitted', async () => {
       const app = express();
 

--- a/src/strict-http-firewall.ts
+++ b/src/strict-http-firewall.ts
@@ -139,6 +139,14 @@ class StrictHttpFirewall {
       if (options.allowedHostnames !== undefined) {
         this.allowedHostnames = options.allowedHostnames;
       }
+
+      if (options.decodedUrlBlockList !== undefined && options.decodedUrlBlockList.length !== 0) {
+        this.decodedUrlBlocklist.push(... options.decodedUrlBlockList);
+      }
+
+      if (options.encodedUrlBlockList !== undefined && options.encodedUrlBlockList.length !== 0) {
+        this.encodedUrlBlocklist.push(... options.encodedUrlBlockList);
+      }
     }
   }
 

--- a/src/types/firewall.models.ts
+++ b/src/types/firewall.models.ts
@@ -231,4 +231,16 @@ export interface HttpFirewallOptions {
    * Default is false
    */
   logToConsole?: boolean;
+
+  /**
+   * A list of strings that are considered malicious in URLs. If these strings are found in the request URL, the
+   * request will be rejected.
+   */
+  decodedUrlBlockList?: string[];
+
+  /**
+   * A list of strings that are considered malicious in encoded URLs. If these strings are found in the request URL, the
+   * request will be rejected.
+   */
+  encodedUrlBlockList?: string[];
 }


### PR DESCRIPTION
### User can provide block lists.

Examples:

```
    it('Should reject request when user provided decoded url block list is provided', async () => {
      const app = express();

      const options: HttpFirewallOptions = {decodedUrlBlockList : ['.exe', '.pl']};
      app.use(httpFirewall(options));
      const res = await request(app).get('/test/some-file.exe').set('Content-Type', 'application/json');
      expect(res.statusCode).toBe(403);
    });

    it('Should reject request when user provided encoded url block list is provided', async () => {
      const app = express();

      const options: HttpFirewallOptions = {encodedUrlBlockList : ['.exe', '.pl']};
      app.use(httpFirewall(options));
      const res = await request(app).get('/test/some-file.exe').set('Content-Type', 'application/json');
      expect(res.statusCode).toBe(403);
    });
```
